### PR TITLE
add: 豆記事投稿バリデーション処理の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,3 +53,5 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'seed-fu', '~> 2.3'
+
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails-i18n (5.1.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     railties (5.1.4)
       actionpack (= 5.1.4)
       activesupport (= 5.1.4)
@@ -170,6 +173,7 @@ DEPENDENCIES
   mysql2 (>= 0.3.18, < 0.5)
   puma (~> 3.0)
   rails (~> 5.1.3)
+  rails-i18n
   sass-rails (~> 5.0)
   seed-fu (~> 2.3)
   spring

--- a/app/controllers/tidbits_controller.rb
+++ b/app/controllers/tidbits_controller.rb
@@ -13,6 +13,7 @@ class TidbitsController < ApplicationController
       content: params[:content]
     )
     if @tidbit.save
+      flash[:notice] = '豆記事を投稿しました。'
       redirect_to('/')
     else
       render('new')

--- a/app/controllers/tidbits_controller.rb
+++ b/app/controllers/tidbits_controller.rb
@@ -4,6 +4,7 @@ class TidbitsController < ApplicationController
   end
 
   def new
+    @tidbit = Tidbit.new
   end
 
   def create
@@ -11,7 +12,10 @@ class TidbitsController < ApplicationController
       title: params[:title],
       content: params[:content]
     )
-    @tidbit.save
-    redirect_to("/")
+    if @tidbit.save
+      redirect_to('/')
+    else
+      render('new')
+    end
   end
 end

--- a/app/models/tidbit.rb
+++ b/app/models/tidbit.rb
@@ -1,2 +1,4 @@
 class Tidbit < ApplicationRecord
+  validates :title, {presence: true, length: {maximum: 30}}
+  validates :content, {presence: true, length: {maximum: 200}}
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
   <body>
     <% if flash[:notice] %>
       <div>
-        フラッシュメッセージ: [<%= flash[:notice] %>]
+        <%= flash[:notice] %>
       </div>
     <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>App</title>
+    <title>Stidbit</title>
     <%= csrf_meta_tags %>
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
@@ -9,6 +9,12 @@
   </head>
 
   <body>
+    <% if flash[:notice] %>
+      <div>
+        フラッシュメッセージ: [<%= flash[:notice] %>]
+      </div>
+    <% end %>
+
     <%= yield %>
   </body>
 </html>

--- a/app/views/tidbits/new.html.erb
+++ b/app/views/tidbits/new.html.erb
@@ -1,11 +1,16 @@
 <%= form_tag("/create") do %>
+  <% @tidbit.errors.full_messages.each do |message| %>
+    <div>
+      <%= message %>
+    </div>
+  <% end %>
   <div>
     <p>タイトル</p>
-    <textarea name="title"></textarea>
+    <textarea name="title"><%= @tidbit.title %></textarea>
   </div>
   <div>
     <p>内容</p>
-    <textarea name="content"></textarea>
+    <textarea name="content"><%= @tidbit.content %></textarea>
   </div>
   <input type="submit" value="投稿">
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,5 +11,6 @@ module App
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,6 @@
+ja:
+  activerecord:
+    attributes:
+      tidbit:
+        title: タイトル
+        content: 内容


### PR DESCRIPTION
## 関連
#21 

## 概要
- 豆記事投稿バリデーションの実装
  * ```validates :title, {presence: true, length: {maximum: 30}}```
  * ```validates :content, {presence: true, length: {maximum: 200}}```

- 投稿成功時のフラッシュメッセージの作成
- バリデーションメッセージの日本語化
  * Gem: ```rails-i18n```

## キャプチャ
- フラッシュメッセージ
<img width="214" alt="2018-02-17 16 18 44" src="https://user-images.githubusercontent.com/17951415/36338999-dc598a16-13fe-11e8-8bae-e0be1c35e501.png">

- バリデーションメッセージ
<img width="372" alt="2018-02-17 16 16 32" src="https://user-images.githubusercontent.com/17951415/36339002-e81c07e8-13fe-11e8-99c7-1adb1f834524.png">